### PR TITLE
Fix extra scrollbar problem

### DIFF
--- a/src/components/Board.svelte
+++ b/src/components/Board.svelte
@@ -22,9 +22,8 @@
     display: flex;
     background-color: lightpink;
     flex-direction: row;
-    flex-wrap: nowrap;
-    height: 100%;
-    width: 100%;
     overflow-x: auto;
+    margin: 8px;
+    gap: 8px;
   }
 </style>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -21,12 +21,13 @@
 </div>
 
 <style>
-  /* CSS here */
-  .parent :global(.header) {
+  .parent {
     background-color: #78c0e0;
-    padding-left: 1.5em;
-    padding-right: 1.5em;
-    height: 100%;
+  }
+  .parent :global(.header) {
+    margin-left: 1.5em;
+    margin-right: 1.5em;
+    padding: 0;
   }
 
   .parent :global(.col1) {

--- a/src/components/List.svelte
+++ b/src/components/List.svelte
@@ -53,7 +53,7 @@
   }
 
   .parent {
-    margin: 10px 10px 10px 10px;
+    /* margin: 10px 10px 10px 10px; */
   }
 
   .parent :global(.container) {

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -13,13 +13,7 @@
     position: relative;
     max-width: 100%;
     background-color: white;
-    /* padding: 2em; */
     margin: 0 auto;
     box-sizing: border-box;
-  }
-
-  slot {
-    max-width: 56em;
-    padding: 2em;
   }
 </style>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -20,13 +20,20 @@
   <title>CalPal</title>
 </svelte:head>
 
-{#if userCards}
-  <Board />
-{:else}
-  <p>Could not get cards.</p>
-{/if}
+<div class="parent">
+  {#if userCards}
+    <Board />
+  {:else}
+    <p>Could not get cards.</p>
+  {/if}
+</div>
 
 <style>
+  .parent {
+    margin-left: 1.5em;
+    margin-right: 1.5em;
+  }
+
   h1,
   figure,
   p {


### PR DESCRIPTION
For some reason, the Header extended past the normal layout. To fix this, we give the parent `div` margins and apply padding to the inner `Row` container. This removes the extra scrollbar that shows up at the bottom of the page.

This pull request additionally improves spacing between elements and removes some unused code in `_layout.svelte`.