### PR TITLE
Use native Sveltestrap props on the Archive Card button

### DIFF
--- a/src/components/ArchiveCard.svelte
+++ b/src/components/ArchiveCard.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <div class="parent">
-  <Button color="#ffffff" on:click={toggle}>
+  <Button outline color="danger" on:click={toggle}>
     <Icon name="archive" />
     Archive Card
   </Button>
@@ -40,10 +40,4 @@
 </div>
 
 <style>
-  .parent {
-    border: solid;
-    border-radius: 8px;
-    border-color: lightgray;
-    border-width: 2px;
-  }
 </style>


### PR DESCRIPTION
Manually setting the color to a certain value removes the hover and
active styles. This patch uses the native Sveltestrap props instead.

The button now looks like this with the changes when hovered:

![image](https://user-images.githubusercontent.com/4997633/114014406-29964980-989b-11eb-9d92-8d945c73fefb.png)

Should we proceed with this? If not, we can go back and try to set the styling up ourselves with CSS.