### PR TITLE
Let ViewCard's date and time pickers use the database date-time fields

### DIFF
--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -6,7 +6,7 @@
     CardSubtitle,
     CardTitle,
   } from "sveltestrap/src";
-  import formattedDate from "../routes/_date-format.js";
+  import { formattedDate } from "../routes/_date-format.js";
 
   export let card;
   export let cardColor;

--- a/src/components/Reminder.svelte
+++ b/src/components/Reminder.svelte
@@ -1,6 +1,6 @@
 <script>
   import { Alert } from "sveltestrap/src";
-  import formattedDate from "../routes/_date-format.js";
+  import { formattedDate } from "../routes/_date-format.js";
 
   export let card;
 

--- a/src/components/Reminder.svelte
+++ b/src/components/Reminder.svelte
@@ -1,15 +1,11 @@
 <script>
   import { Alert } from "sveltestrap/src";
   import formattedDate from "../routes/_date-format.js";
+
   export let card;
 
   $: dueDate = formattedDate(new Date(card.due_date_time));
   $: cardName = card.card_name;
-  $: {
-    if (card.due_date_time === "") {
-      card.remind_date_time = "";
-    }
-  }
   let visible = true;
 </script>
 

--- a/src/components/ViewCard.svelte
+++ b/src/components/ViewCard.svelte
@@ -57,13 +57,11 @@
       const timeString = `${dateTimeStrings.hours}:${dateTimeStrings.minutes}`;
 
       if (date.toISOString().split("T").length === 1) {
-        console.debug(`[ViewCard.svelte] No time. Returning date only.`);
         return {
           date: dateString,
           time: "",
         };
       } else {
-        console.debug(`[ViewCard.svelte] Returning date and time.`);
         return {
           date: dateString,
           time: timeString,
@@ -76,13 +74,6 @@
   let remindDateTime = initializeDateTimeFromString(card.remind_date_time);
 
   $: {
-    console.debug(
-      `[ViewCard.svelte] dueDateTime: ${JSON.stringify(dueDateTime)}`
-    );
-    console.debug(
-      `[ViewCard.svelte] remindDateTime: ${JSON.stringify(remindDateTime)}`
-    );
-
     if (dueDateTime.date === "") {
       dueDateTime.time = "";
       remindDateTime.date = "";
@@ -96,11 +87,6 @@
       const newDueDateTime = new Date(
         `${dueDateTime.date} ${dueDateTime.time}`
       );
-      if (newDueDateTime.toString() === "Invalid Date") {
-        console.error(
-          `[ViewCard.svelte] Could not create new date with '${dueDateTime.date} ${dueDateTime.time}'`
-        );
-      }
       card.due_date_time = newDueDateTime;
       card.remind_date_time = new Date(
         `${remindDateTime.date} ${remindDateTime.time}`

--- a/src/components/ViewCard.svelte
+++ b/src/components/ViewCard.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { stores } from "@sapper/app";
   import {
     Modal,
     ModalBody,
@@ -22,8 +21,6 @@
     formattedDate,
     getDateAndTimeStringsFromDate,
   } from "../routes/_date-format.js";
-
-  const { session } = stores();
 
   export let card;
   // TODO: When toggling isArchived, all footer elements appear at

--- a/src/components/ViewCard.svelte
+++ b/src/components/ViewCard.svelte
@@ -39,6 +39,74 @@
       cardColor = "#AAAAAA";
     }
   }
+
+  const initializeDateTimeFromString = (dateString) => {
+    const date = new Date(dateString);
+
+    if (date.toString() === "Invalid Date") {
+      return { date: "", time: "" };
+    } else {
+      const dateTimeStrings = {
+        year: date.getFullYear(),
+        month: (date.getMonth() + 1).toString().padStart(2, "0"),
+        date: date.getDate().toString().padStart(2, "0"),
+        hours: date.getHours().toString().padStart(2, "0"),
+        minutes: date.getMinutes().toString().padStart(2, "0"),
+      };
+      const dateString = `${dateTimeStrings.year}-${dateTimeStrings.month}-${dateTimeStrings.date}`;
+      const timeString = `${dateTimeStrings.hours}:${dateTimeStrings.minutes}`;
+
+      if (date.toISOString().split("T").length === 1) {
+        console.debug(`[ViewCard.svelte] No time. Returning date only.`);
+        return {
+          date: dateString,
+          time: "",
+        };
+      } else {
+        console.debug(`[ViewCard.svelte] Returning date and time.`);
+        return {
+          date: dateString,
+          time: timeString,
+        };
+      }
+    }
+  };
+
+  let dueDateTime = initializeDateTimeFromString(card.due_date_time);
+  let remindDateTime = initializeDateTimeFromString(card.remind_date_time);
+
+  $: {
+    console.debug(
+      `[ViewCard.svelte] dueDateTime: ${JSON.stringify(dueDateTime)}`
+    );
+    console.debug(
+      `[ViewCard.svelte] remindDateTime: ${JSON.stringify(remindDateTime)}`
+    );
+
+    if (dueDateTime.date === "") {
+      dueDateTime.time = "";
+      remindDateTime.date = "";
+      remindDateTime.time = "";
+      card.due_date_time = "";
+      card.remind_date_time = "";
+    } else if (remindDateTime.date === "") {
+      remindDateTime.time = "";
+      card.remind_date_time = "";
+    } else {
+      const newDueDateTime = new Date(
+        `${dueDateTime.date} ${dueDateTime.time}`
+      );
+      if (newDueDateTime.toString() === "Invalid Date") {
+        console.error(
+          `[ViewCard.svelte] Could not create new date with '${dueDateTime.date} ${dueDateTime.time}'`
+        );
+      }
+      card.due_date_time = newDueDateTime;
+      card.remind_date_time = new Date(
+        `${remindDateTime.date} ${remindDateTime.time}`
+      );
+    }
+  }
 </script>
 
 <div class="view-card-parent" style="--card-color: {cardColor}">
@@ -96,7 +164,7 @@
                 type="date"
                 name="dueDate"
                 id="dueDate"
-                bind:value={card.due_date_time}
+                bind:value={dueDateTime.date}
                 disabled={isArchived}
               />
             </FormGroup>
@@ -108,7 +176,8 @@
                 type="time"
                 name="dueTime"
                 id="dueTime"
-                disabled={card.due_date_time === "" || isArchived}
+                bind:value={dueDateTime.time}
+                disabled={dueDateTime.date === "" || isArchived}
               />
             </FormGroup>
           </Col>
@@ -121,8 +190,8 @@
                 type="date"
                 name="reminderDate"
                 id="reminderDate"
-                bind:value={card.remind_date_time}
-                disabled={card.due_date_time === "" || isArchived}
+                bind:value={remindDateTime.date}
+                disabled={dueDateTime.date === "" || isArchived}
               />
             </FormGroup>
           </Col>
@@ -133,7 +202,8 @@
                 type="time"
                 name="reminderTime"
                 id="reminderTime"
-                disabled={card.remind_date_time === "" || isArchived}
+                bind:value={remindDateTime.time}
+                disabled={remindDateTime.date === "" || isArchived}
               />
             </FormGroup>
           </Col>

--- a/src/components/ViewCard.svelte
+++ b/src/components/ViewCard.svelte
@@ -18,7 +18,10 @@
   import Title from "./Title.svelte";
   import ColorPicker from "./ColorPicker.svelte";
   import ArchiveCard from "./ArchiveCard.svelte";
-  import formattedDate from "../routes/_date-format.js";
+  import {
+    formattedDate,
+    getDateAndTimeStringsFromDate,
+  } from "../routes/_date-format.js";
 
   const { session } = stores();
 
@@ -40,38 +43,10 @@
     }
   }
 
-  const initializeDateTimeFromString = (dateString) => {
-    const date = new Date(dateString);
-
-    if (date.toString() === "Invalid Date") {
-      return { date: "", time: "" };
-    } else {
-      const dateTimeStrings = {
-        year: date.getFullYear(),
-        month: (date.getMonth() + 1).toString().padStart(2, "0"),
-        date: date.getDate().toString().padStart(2, "0"),
-        hours: date.getHours().toString().padStart(2, "0"),
-        minutes: date.getMinutes().toString().padStart(2, "0"),
-      };
-      const dateString = `${dateTimeStrings.year}-${dateTimeStrings.month}-${dateTimeStrings.date}`;
-      const timeString = `${dateTimeStrings.hours}:${dateTimeStrings.minutes}`;
-
-      if (date.toISOString().split("T").length === 1) {
-        return {
-          date: dateString,
-          time: "",
-        };
-      } else {
-        return {
-          date: dateString,
-          time: timeString,
-        };
-      }
-    }
-  };
-
-  let dueDateTime = initializeDateTimeFromString(card.due_date_time);
-  let remindDateTime = initializeDateTimeFromString(card.remind_date_time);
+  let dueDateTime = getDateAndTimeStringsFromDate(new Date(card.due_date_time));
+  let remindDateTime = getDateAndTimeStringsFromDate(
+    new Date(card.remind_date_time)
+  );
 
   $: {
     if (dueDateTime.date === "") {

--- a/src/routes/_date-format.js
+++ b/src/routes/_date-format.js
@@ -41,7 +41,7 @@ const dayNames = {
   ],
 };
 
-export default function formattedDate(inputDate) {
+export function formattedDate(inputDate) {
   if (inputDate.toString() === "Invalid Date") {
     return "";
   }
@@ -50,4 +50,38 @@ export default function formattedDate(inputDate) {
   return `${dayNames["short"][day]}, ${
     monthNames["long"][month - 1]
   } ${date}, ${year}`;
+}
+
+// Returns an object containing the `date` and `time` fields.
+// Both fields are strings. If the date is invalid,
+// both the `date` and `time` fields will be the empty string.
+// If the input date object doesn't have an included time,
+// Only the `date` field will have a value, and `time` will
+// remain an empty string.
+export function getDateAndTimeStringsFromDate(date) {
+  if (date.toString() === "Invalid Date") {
+    return { date: "", time: "" };
+  } else {
+    const dateTimeStrings = {
+      year: date.getFullYear(),
+      month: (date.getMonth() + 1).toString().padStart(2, "0"),
+      date: date.getDate().toString().padStart(2, "0"),
+      hours: date.getHours().toString().padStart(2, "0"),
+      minutes: date.getMinutes().toString().padStart(2, "0"),
+    };
+    const dateString = `${dateTimeStrings.year}-${dateTimeStrings.month}-${dateTimeStrings.date}`;
+    const timeString = `${dateTimeStrings.hours}:${dateTimeStrings.minutes}`;
+
+    if (date.toISOString().split("T").length === 1) {
+      return {
+        date: dateString,
+        time: "",
+      };
+    } else {
+      return {
+        date: dateString,
+        time: timeString,
+      };
+    }
+  }
 }


### PR DESCRIPTION
This patch makes it so the Due Date and Time fields edit the Card's
`card.due_date_time` field in the database, and the Reminder and Time
fields edit the Card's `card.remind_date_time` field in the database.

This works by splitting up the database fields into separate date and
time strings. We then bind the ViewCard input fields to these separate
strings.

Once changes are made, the strings of each input field are merged back
into a single string, which is then stored in the database.

This solves the problem where binding multiple input fields to one
database field would remove any previous changes.