### PR TITLE
Use SSL certs in production

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -4,9 +4,8 @@ import compression from "compression";
 import * as sapper from "@sapper/server";
 import session from "express-session";
 import { json } from "body-parser";
-
-const { createServer } = require("https");
-const { readFileSync } = require("fs");
+import { createServer } from "https";
+import { readFileSync } from "fs";
 
 const { PORT, NODE_ENV, GOOGLE_OAUTH2_CLIENT_ID } = process.env;
 const dev = NODE_ENV === "development";


### PR DESCRIPTION
This lets CalPal now use HTTPS, thanks to [Let's Encrypt!](https://letsencrypt.org/)

We need this for two reasons:

- To set CalPal's deployment status to "Production" on the Google Cloud Console. This means that we won't be limited to a whitelist of 100 users.
- To access a user's calendars from their Google Calendar.

Only the live server uses the SSL certs. There's apparently no need to think about HTTPS when running a local development server because `localhost` lets us do the same things an HTTPS domain can, more or less.