### PR TITLE
Delete attachments of Cards in Folders and Lists

### DIFF
--- a/src/components/Folder.svelte
+++ b/src/components/Folder.svelte
@@ -59,6 +59,16 @@
   }
 
   async function deleteFolder () {
+    await fetch(`/api/card/attachment/delete/folder/${folder._id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        user_id: $session.user_id,
+      }),
+    });
+
     $session.lists = $session.lists.map((list) => {
       if (list._id !== listId) {
         return list;

--- a/src/components/Folder.svelte
+++ b/src/components/Folder.svelte
@@ -80,13 +80,10 @@
       );
       return list;
     });
-<<<<<<< HEAD
-=======
   };
 
   function handleSort(e) {
     folder.cards = e.detail.items;
->>>>>>> origin/development
   }
 </script>
 

--- a/src/components/Folder.svelte
+++ b/src/components/Folder.svelte
@@ -58,8 +58,8 @@
     ];
   }
 
-  async function deleteFolder () {
-    await fetch(`/api/card/attachment/delete/folder/${folder._id}`, {
+  function deleteFolder () {
+    fetch(`/api/card/attachment/delete/folder/${folder._id}`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",

--- a/src/components/Folder.svelte
+++ b/src/components/Folder.svelte
@@ -60,7 +60,7 @@
     ];
   }
 
-  function deleteFolder () {
+  function deleteFolder() {
     fetch(`/api/card/attachment/delete/folder/${folder._id}`, {
       method: "DELETE",
       headers: {
@@ -75,12 +75,10 @@
       if (list._id !== listId) {
         return list;
       }
-      list.cards = list.cards.filter(
-        (f) => f._id !== folder._id
-      );
+      list.cards = list.cards.filter((f) => f._id !== folder._id);
       return list;
     });
-  };
+  }
 
   function handleSort(e) {
     folder.cards = e.detail.items;

--- a/src/components/Folder.svelte
+++ b/src/components/Folder.svelte
@@ -58,17 +58,17 @@
     ];
   }
 
-  const deleteFolder = (folderIdToDelete) => {
+  async function deleteFolder () {
     $session.lists = $session.lists.map((list) => {
       if (list._id !== listId) {
         return list;
       }
       list.cards = list.cards.filter(
-        (folder) => folder._id !== folderIdToDelete
+        (f) => f._id !== folder._id
       );
       return list;
     });
-  };
+  }
 </script>
 
 <Card style="width: 100%;">

--- a/src/components/List.svelte
+++ b/src/components/List.svelte
@@ -51,6 +51,7 @@
         user_id: $session.user_id,
       }),
     });
+
     $session.lists = $session.lists.filter((l) => {
       if (l._id === list._id) {
         return false;

--- a/src/components/List.svelte
+++ b/src/components/List.svelte
@@ -39,6 +39,15 @@
   };
 
   function deleteList() {
+    fetch(`/api/card/attachment/delete/list/${list._id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        user_id: $session.user_id,
+      }),
+    });
     $session.lists = $session.lists.filter((l) => {
       if (l._id === list._id) {
         return false;

--- a/src/routes/api/_database.js
+++ b/src/routes/api/_database.js
@@ -149,7 +149,7 @@ export async function deleteAttachmentsOfCard(cardId) {
 }
 
 //TODO: Find a way to make Mongo do the parsing and deleting work
-export async function deleteAttachmentsinFolder(userId, folderId) {
+export async function deleteAttachmentsInFolder(userId, folderId) {
   const userData = await getUserData(userId);
   let folder;
 
@@ -164,11 +164,9 @@ export async function deleteAttachmentsinFolder(userId, folderId) {
   for (const card of folder.cards) {
     deleteAttachmentsOfCard(card._id);
   }
-
-  return;
 }
 
-export async function deleteAttachmentsinList(userId, listId) {
+export async function deleteAttachmentsInList(userId, listId) {
   const userData = await getUserData(userId);
 
   for (const list of userData.lists) {
@@ -177,7 +175,7 @@ export async function deleteAttachmentsinList(userId, listId) {
         if (element.card_name) {
           deleteAttachmentsOfCard(element._id);
         } else if (element.folder_name) {
-          deleteAttachmentsinFolder(userId, element._id);
+          deleteAttachmentsInFolder(userId, element._id);
         }
       }
     }

--- a/src/routes/api/_database.js
+++ b/src/routes/api/_database.js
@@ -132,10 +132,8 @@ export async function deleteAttachmentsOfCard(cardId) {
 
 //TODO: Find a way to make Mongo do the parsing and deleting work
 export async function deleteAttachmentsinFolder(userId, folderId) {
-  console.debug(userId);
   const userCards = await getUserData(userId);
   let folder;
-  console.debug(JSON.stringify(userCards, null, 2));
 
   for (const list of userCards.lists) {
     for (const element of list.cards) {

--- a/src/routes/api/_database.js
+++ b/src/routes/api/_database.js
@@ -150,6 +150,24 @@ export async function deleteAttachmentsinFolder(userId, folderId) {
   return;
 }
 
+export async function deleteAttachmentsinList(userId, listId) {
+  const userCards = await getUserData(userId);
+
+  for (const list of userCards.lists) {
+    if (list._id === listId) {
+      for (const element of list.cards) {
+        if (element.card_name) {
+          deleteAttachmentsOfCard(element._id);
+        } else if (element.folder_name) {
+          deleteAttachmentsinFolder(userId, element._id);
+        }
+      }
+    }
+  }
+
+  return;
+}
+
 export async function getCalendarsOfUser(userId) {
   const db = await getDb();
   const result = await db.collection("calendars").findOne({ user_id: userId });

--- a/src/routes/api/_database.js
+++ b/src/routes/api/_database.js
@@ -180,8 +180,6 @@ export async function deleteAttachmentsInList(userId, listId) {
       }
     }
   }
-
-  return;
 }
 
 export async function getCalendarsOfUser(userId) {

--- a/src/routes/api/_database.js
+++ b/src/routes/api/_database.js
@@ -130,6 +130,28 @@ export async function deleteAttachmentsOfCard(cardId) {
   return result;
 }
 
+//TODO: Find a way to make Mongo do the parsing and deleting work
+export async function deleteAttachmentsinFolder(userId, folderId) {
+  console.debug(userId);
+  const userCards = await getUserData(userId);
+  let folder;
+  console.debug(JSON.stringify(userCards, null, 2));
+
+  for (const list of userCards.lists) {
+    for (const element of list.cards) {
+      if (element._id === folderId) {
+        folder = element;
+      }
+    }
+  }
+
+  for (const card of folder.cards) {
+    deleteAttachmentsOfCard(card._id);
+  }
+
+  return;
+}
+
 export async function getCalendarsOfUser(userId) {
   const db = await getDb();
   const result = await db.collection("calendars").findOne({ user_id: userId });

--- a/src/routes/api/_database.js
+++ b/src/routes/api/_database.js
@@ -22,9 +22,9 @@ export async function getUserData(userId) {
   const db = await getDb();
   const cards = db.collection("cards");
 
-  const userCards = await cards.findOne({ user_id: userId });
+  const userData = await cards.findOne({ user_id: userId });
 
-  return userCards;
+  return userData;
 }
 
 export async function updateUserData(userId, lists, archived_cards, calendars) {
@@ -132,10 +132,10 @@ export async function deleteAttachmentsOfCard(cardId) {
 
 //TODO: Find a way to make Mongo do the parsing and deleting work
 export async function deleteAttachmentsinFolder(userId, folderId) {
-  const userCards = await getUserData(userId);
+  const userData = await getUserData(userId);
   let folder;
 
-  for (const list of userCards.lists) {
+  for (const list of userData.lists) {
     for (const element of list.cards) {
       if (element._id === folderId) {
         folder = element;
@@ -151,9 +151,9 @@ export async function deleteAttachmentsinFolder(userId, folderId) {
 }
 
 export async function deleteAttachmentsinList(userId, listId) {
-  const userCards = await getUserData(userId);
+  const userData = await getUserData(userId);
 
-  for (const list of userCards.lists) {
+  for (const list of userData.lists) {
     if (list._id === listId) {
       for (const element of list.cards) {
         if (element.card_name) {

--- a/src/routes/api/card/attachment/delete/folder/[folderId].js
+++ b/src/routes/api/card/attachment/delete/folder/[folderId].js
@@ -3,9 +3,6 @@ import { deleteAttachmentsinFolder } from "../../../../_database.js";
 export async function del(req, res) {
   const { folderId } = req.params;
   const userId = req.body.user_id;
-  //   console.debug(userId);
-
-  //   console.debug(folderId);
 
   await deleteAttachmentsinFolder(userId, folderId);
 

--- a/src/routes/api/card/attachment/delete/folder/[folderId].js
+++ b/src/routes/api/card/attachment/delete/folder/[folderId].js
@@ -1,10 +1,10 @@
-import { deleteAttachmentsinFolder } from "../../../../_database.js";
+import { deleteAttachmentsInFolder } from "../../../../_database.js";
 
 export async function del(req, res) {
   const { folderId } = req.params;
   const userId = req.body.user_id;
 
-  await deleteAttachmentsinFolder(userId, folderId);
+  await deleteAttachmentsInFolder(userId, folderId);
 
   res.end();
 }

--- a/src/routes/api/card/attachment/delete/folder/[folderId].js
+++ b/src/routes/api/card/attachment/delete/folder/[folderId].js
@@ -1,0 +1,13 @@
+import { deleteAttachmentsinFolder } from "../../../../_database.js";
+
+export async function del(req, res) {
+  const { folderId } = req.params;
+  const userId = req.body.user_id;
+  //   console.debug(userId);
+
+  //   console.debug(folderId);
+
+  await deleteAttachmentsinFolder(userId, folderId);
+
+  res.end();
+}

--- a/src/routes/api/card/attachment/delete/list/[listId].js
+++ b/src/routes/api/card/attachment/delete/list/[listId].js
@@ -1,10 +1,10 @@
-import { deleteAttachmentsinList } from "../../../../_database.js";
+import { deleteAttachmentsInList } from "../../../../_database.js";
 
 export async function del(req, res) {
   const { listId } = req.params;
   const userId = req.body.user_id;
 
-  await deleteAttachmentsinList(userId, listId);
+  await deleteAttachmentsInList(userId, listId);
 
   res.end();
 }

--- a/src/routes/api/card/attachment/delete/list/[listId].js
+++ b/src/routes/api/card/attachment/delete/list/[listId].js
@@ -1,0 +1,10 @@
+import { deleteAttachmentsinList } from "../../../../_database.js";
+
+export async function del(req, res) {
+  const { listId } = req.params;
+  const userId = req.body.user_id;
+
+  await deleteAttachmentsinList(userId, listId);
+
+  res.end();
+}


### PR DESCRIPTION
This pull requests solves the issue of attachments of cards in folders and lists not being deleted when the respective folder or list is deleted. This is handled by having a respective endpoint for folder and list and fetching that endpoint when a list or a folder is deleted. The database function for deleting a folder parses the folder's cards and calls the function to delete the attachments of that card. The database function for deleting a list parses the elements of a list and calls the function to delete attachments of a card if it finds a card and calls the function for delete folder attachments if it finds a folder.