### PR TITLE
Check attachments for size and type before uploading

### DIFF
--- a/src/components/Attachment.svelte
+++ b/src/components/Attachment.svelte
@@ -7,7 +7,7 @@
   export let attachments = [],
     name = "attachments",
     accept =
-      ".svg, .jpg, .jpeg, .png, .gif, .docx, .pdf, .txt, .py, .xlsx, .js, .htm, .html, .mp3, .wav",
+      ".svg, .jpg, .jpeg, .png, .gif, .docx, .pdf, .txt, .py, .xlsx, .js, .htm, .html, .mp3, .wav, .zip, .rar",
     error = false,
     multiple = "true",
     disabled = false;
@@ -39,6 +39,8 @@
     "text/html",
     "audio/mpeg",
     "audio/wav",
+    "application/zip",
+    "application/vnd.rar",
   ];
 
   const isImage = (string) => /\.(jpe?g|pn?g|gi?f|sv?g)$/i.test(string);

--- a/src/components/Attachment.svelte
+++ b/src/components/Attachment.svelte
@@ -24,7 +24,8 @@
 
   let errorMessage = "";
 
-  const maxFileSize = 5000000
+  const maxFileSize = 5000000;
+  const acceptedFileTypes = ["image/svg+xml","image/jpeg","image/png","image/gif","application/vnd.openxmlformats-officedocument.wordprocessingml.document","application/pdf","text/plain","application/vnd.openxmlformats-officedocument.spreadsheetml.sheet","text/javascript","text/html","audio/mpeg","audio/wav"];
 
   const isImage = (string) => /\.(jpe?g|pn?g|gi?f|sv?g)$/i.test(string);
   const imagePreviewStyle = (file) =>

--- a/src/components/Attachment.svelte
+++ b/src/components/Attachment.svelte
@@ -62,6 +62,12 @@
         return;
       }
 
+      if (!acceptedFileTypes.includes(file.type)){
+        errorMessage =
+          "The attachment type is unsupported and cannot be uploaded";
+        return;
+      }
+
       const reader = new FileReader();
       reader.onload = function (e) {
         const newAttachment = {

--- a/src/components/Attachment.svelte
+++ b/src/components/Attachment.svelte
@@ -22,6 +22,8 @@
     });
   }
 
+  let errorMessage = "";
+
   const isImage = (string) => /\.(jpe?g|pn?g|gi?f|sv?g)$/i.test(string);
   const imagePreviewStyle = (file) =>
     isImage(file.data.filename)
@@ -119,6 +121,9 @@
       {/each}
     </ul>
   {/if}
+  {#if errorMessage}
+    <p class="error-message">{errorMessage}</p>
+  {/if}
 </div>
 
 <style>
@@ -181,5 +186,9 @@
 
   .attachment-parent :global(.attachment-delete-button:active) {
     color: rgba(0, 0, 0, 1);
+  }
+
+  .error-message {
+    color: var(--bs-red);
   }
 </style>

--- a/src/components/Attachment.svelte
+++ b/src/components/Attachment.svelte
@@ -6,7 +6,7 @@
   export let cardId;
   export let attachments = [],
     name = "attachments",
-    accept = ".svg, .jpg, .png, .gif, .doc, .docx, .pdf, .txt",
+    accept = ".svg, .jpg, .jpeg, .png, .gif, .docx, .pdf, .txt, .py, .xlsx, .js, .htm, .html, .mp3, .wav",
     error = false,
     multiple = "true",
     disabled = false;

--- a/src/components/Attachment.svelte
+++ b/src/components/Attachment.svelte
@@ -52,9 +52,10 @@
     error = false;
     function readAndPreview(file) {
       errorMessage = "";
-      
+
       if (file.size > 5000000) {
-        errorMessage = "The attachment size exceeds 5 MB and cannot be uploaded."
+        errorMessage =
+          "The attachment size exceeds 5 MB and cannot be uploaded.";
         return;
       }
 

--- a/src/components/Attachment.svelte
+++ b/src/components/Attachment.svelte
@@ -24,6 +24,8 @@
 
   let errorMessage = "";
 
+  const maxFileSize = 5000000
+
   const isImage = (string) => /\.(jpe?g|pn?g|gi?f|sv?g)$/i.test(string);
   const imagePreviewStyle = (file) =>
     isImage(file.data.filename)
@@ -53,7 +55,7 @@
     function readAndPreview(file) {
       errorMessage = "";
 
-      if (file.size > 5000000) {
+      if (file.size > maxFileSize) {
         errorMessage =
           "The attachment size exceeds 5 MB and cannot be uploaded.";
         return;

--- a/src/components/Attachment.svelte
+++ b/src/components/Attachment.svelte
@@ -49,6 +49,13 @@
   function previewFiles(e) {
     error = false;
     function readAndPreview(file) {
+      errorMessage = "";
+      
+      if (file.size > 5000000) {
+        errorMessage = "The attachment size exceeds 5 MB and cannot be uploaded."
+        return;
+      }
+
       const reader = new FileReader();
       reader.onload = function (e) {
         const newAttachment = {

--- a/src/components/Attachment.svelte
+++ b/src/components/Attachment.svelte
@@ -6,7 +6,8 @@
   export let cardId;
   export let attachments = [],
     name = "attachments",
-    accept = ".svg, .jpg, .jpeg, .png, .gif, .docx, .pdf, .txt, .py, .xlsx, .js, .htm, .html, .mp3, .wav",
+    accept =
+      ".svg, .jpg, .jpeg, .png, .gif, .docx, .pdf, .txt, .py, .xlsx, .js, .htm, .html, .mp3, .wav",
     error = false,
     multiple = "true",
     disabled = false;
@@ -25,7 +26,20 @@
   let errorMessage = "";
 
   const maxFileSize = 5000000;
-  const acceptedFileTypes = ["image/svg+xml","image/jpeg","image/png","image/gif","application/vnd.openxmlformats-officedocument.wordprocessingml.document","application/pdf","text/plain","application/vnd.openxmlformats-officedocument.spreadsheetml.sheet","text/javascript","text/html","audio/mpeg","audio/wav"];
+  const acceptedFileTypes = [
+    "image/svg+xml",
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/pdf",
+    "text/plain",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "text/javascript",
+    "text/html",
+    "audio/mpeg",
+    "audio/wav",
+  ];
 
   const isImage = (string) => /\.(jpe?g|pn?g|gi?f|sv?g)$/i.test(string);
   const imagePreviewStyle = (file) =>
@@ -62,7 +76,7 @@
         return;
       }
 
-      if (!acceptedFileTypes.includes(file.type)){
+      if (!acceptedFileTypes.includes(file.type)) {
         errorMessage =
           "The attachment type is unsupported and cannot be uploaded";
         return;


### PR DESCRIPTION
This pull request handles the checking of the uploaded attachments to verify if they can be uploaded or not.

This prevents attachments of size larger than 5 MB being uploaded as well as files that are not of the accepted file extensions. 