### PR TITLE
Support Google Calendars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /src/node_modules/@sapper/
 yarn-error.log
 /__sapper__/
+/secrets/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "compression": "^1.7.1",
         "express-session": "^1.17.1",
         "google-auth-library": "^7.0.4",
+        "googleapis": "^76.0.0",
         "mongodb": "^3.6.5",
         "node-ical": "^0.13.0",
         "polka": "next",
@@ -4944,6 +4945,34 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "76.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-76.0.0.tgz",
+      "integrity": "sha512-l/TFSW7IRFcb7wF641BlmuP8Ox1ncuzJk5Fcs2947otlGBm5ktDxFhPkmrcNDaG+LWPQsuDwP1ojL0xV39cpmw==",
+      "dependencies": {
+        "google-auth-library": "^7.0.2",
+        "googleapis-common": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-5.0.2.tgz",
+      "integrity": "sha512-TL7qronKNZwE/XBvqshwzCPmZGq2gz/beXzANF7EVoO7FsQjOd7dk40DYrXkoCpvbnJHCQKWESq6NansiIPFqA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^4.0.0",
+        "google-auth-library": "^7.0.2",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10.10.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -10198,6 +10227,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -14374,6 +14408,28 @@
         "node-forge": "^0.10.0"
       }
     },
+    "googleapis": {
+      "version": "76.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-76.0.0.tgz",
+      "integrity": "sha512-l/TFSW7IRFcb7wF641BlmuP8Ox1ncuzJk5Fcs2947otlGBm5ktDxFhPkmrcNDaG+LWPQsuDwP1ojL0xV39cpmw==",
+      "requires": {
+        "google-auth-library": "^7.0.2",
+        "googleapis-common": "^5.0.2"
+      }
+    },
+    "googleapis-common": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-5.0.2.tgz",
+      "integrity": "sha512-TL7qronKNZwE/XBvqshwzCPmZGq2gz/beXzANF7EVoO7FsQjOd7dk40DYrXkoCpvbnJHCQKWESq6NansiIPFqA==",
+      "requires": {
+        "extend": "^3.0.2",
+        "gaxios": "^4.0.0",
+        "google-auth-library": "^7.0.2",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^8.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -18342,6 +18398,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "compression": "^1.7.1",
     "express-session": "^1.17.1",
     "google-auth-library": "^7.0.4",
+    "googleapis": "^76.0.0",
     "mongodb": "^3.6.5",
     "node-ical": "^0.13.0",
     "polka": "next",

--- a/src/components/AddCalendar.svelte
+++ b/src/components/AddCalendar.svelte
@@ -27,7 +27,7 @@
 
   let open = false;
   let calendarName = "";
-  let inputUrl = "";
+  let inputSrc = "";
   let errorMessage = "";
 
   const toggle = () => {
@@ -36,7 +36,7 @@
 
   const clearFields = () => {
     calendarName = "";
-    inputUrl = "";
+    inputSrc = "";
   };
 
   $: {
@@ -46,8 +46,8 @@
     }
   }
 
-  const getCardsFromUrl = async (url) => {
-    const response = await fetch(`/api/ical/parse.json?url=${url}`, {
+  const getCardsFromUrl = async (src) => {
+    const response = await fetch(`/api/ical/parse.json?src=${src}`, {
       headers: {
         "Content-Type": "application/json",
       },
@@ -87,7 +87,7 @@
       {
         _id: getObjectId(),
         name: calendarName,
-        url: inputUrl,
+        src: inputSrc,
       },
     ];
   };
@@ -133,7 +133,7 @@
                 name="url"
                 id="add-calendar-url"
                 placeholder="Calendar URL"
-                bind:value={inputUrl}
+                bind:value={inputSrc}
               />
             </FormGroup>
             {#if errorMessage}
@@ -148,13 +148,13 @@
       <Button
         color="primary"
         on:click={async () => {
-          if (!calendarName || !inputUrl) {
+          if (!calendarName || !inputSrc) {
             errorMessage = "Both fields are required.";
             return;
           }
 
           try {
-            await getCardsFromUrl(inputUrl);
+            await getCardsFromUrl(inputSrc);
             await addCalendar();
             toggle();
             clearFields();

--- a/src/components/AddCalendar.svelte
+++ b/src/components/AddCalendar.svelte
@@ -47,7 +47,8 @@
   }
 
   const getCardsFromUrl = async (src) => {
-    const response = await fetch(`/api/ical/parse.json?src=${src}`, {
+    const encodedSrc = encodeURIComponent(src);
+    const response = await fetch(`/api/ical/parse.json?src=${encodedSrc}`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/src/components/SignIn.svelte
+++ b/src/components/SignIn.svelte
@@ -83,8 +83,14 @@
   let googleApiScript;
 
   const renderSignInButton = () => {
+    const scopes = [
+      "profile",
+      "https://www.googleapis.com/auth/calendar.events.readonly",
+    ];
+
     /*global gapi*/
     gapi.signin2.render("g-sign-in", {
+      scope: scopes.join(" "),
       longtitle: true,
       onsuccess: async (googleUser) => {
         const { id_token, access_token } = googleUser.getAuthResponse(true);

--- a/src/components/SyncedCalendarsSidebar.svelte
+++ b/src/components/SyncedCalendarsSidebar.svelte
@@ -90,7 +90,7 @@
                 </CardHeader>
                 <CardBody>
                   <code>
-                    {calendar.url}
+                    {calendar.src}
                   </code>
                 </CardBody>
               </Card>

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -3,7 +3,21 @@
 
   export async function preload(_page, session) {
     if (session.did_cards_load) {
-      await syncCards(session, this.fetch);
+      try {
+        const res = await this.fetch(`/api/card/${session.user_id}.json`);
+        if (!res.ok) {
+          throw new Error("Could not retrieve user data");
+        }
+
+        const userData = await res.json();
+        for (const key in userData) {
+          session[key] = userData[key];
+        }
+
+        await syncCards(session, this.fetch);
+      } catch (err) {
+        console.error(err);
+      }
     }
   }
 </script>

--- a/src/routes/api/ical/_ical.js
+++ b/src/routes/api/ical/_ical.js
@@ -1,4 +1,7 @@
 const ical = require("node-ical");
+const { google } = require("googleapis");
+
+const { GOOGLE_OAUTH2_CLIENT_ID, GOOGLE_OAUTH2_CLIENT_SECRET } = process.env;
 
 export async function getCardsFromUrl(calendarSrc) {
   const events = await ical.async.fromURL(calendarSrc);
@@ -25,7 +28,61 @@ export async function getCardsFromUrl(calendarSrc) {
         color: "#ffffff",
       };
     })
-    .filter((c) => c);
+    .filter((c) => !!c);
 
   return cardsFromEvents;
+}
+
+export async function getCardsFromGoogleCalendarId(calendarSrc, accessToken) {
+  const oAuth2Client = new google.auth.OAuth2(
+    GOOGLE_OAUTH2_CLIENT_ID,
+    GOOGLE_OAUTH2_CLIENT_SECRET
+  );
+  oAuth2Client.setCredentials({
+    access_token: accessToken,
+  });
+
+  const calendar = google.calendar({
+    version: "v3",
+    auth: oAuth2Client,
+  });
+
+  try {
+    const res = await calendar.events.list({
+      calendarId: calendarSrc,
+      timeMin: new Date(Date.now()),
+    });
+    const cardsFromEvents = Object.entries(res.data.items)
+      .map(([_, e]) => {
+        if (!e.id) {
+          return null;
+        }
+
+        let startDate;
+        if (e.start.date != null) {
+          startDate = new Date(e.start.date);
+        } else if (e.start.dateTime) {
+          startDate = new Date(e.start.dateTime);
+        }
+
+        return {
+          _id: e.id,
+          card_name: e.summary,
+          original_title: e.summary,
+          original_calendar: calendarSrc,
+          original_date: startDate,
+          date_created: new Date(Date.now()),
+          due_date_time: "",
+          remind_date_time: "",
+          description: e.description,
+          color: "#ffffff",
+        };
+      })
+      .filter((e) => !!e);
+
+    return cardsFromEvents;
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
 }

--- a/src/routes/api/ical/_ical.js
+++ b/src/routes/api/ical/_ical.js
@@ -1,7 +1,7 @@
 const ical = require("node-ical");
 
-export async function getCardsFromUrl(calendarUrl) {
-  const events = await ical.async.fromURL(calendarUrl);
+export async function getCardsFromUrl(calendarSrc) {
+  const events = await ical.async.fromURL(calendarSrc);
   const cardsFromEvents = Object.entries(events)
     .map(([_, e]) => {
       if (!e.uid) {
@@ -16,7 +16,7 @@ export async function getCardsFromUrl(calendarUrl) {
         _id: e.uid,
         card_name: e.summary,
         original_title: e.summary,
-        original_calendar: calendarUrl,
+        original_calendar: calendarSrc,
         original_date: e.start,
         date_created: new Date(Date.now()),
         due_date_time: "",

--- a/src/routes/api/ical/parse.json.js
+++ b/src/routes/api/ical/parse.json.js
@@ -18,13 +18,13 @@ export async function get(req, res, next) {
   //
   //       For now, we hackishly put the rest of the `query` back
   //       together with the calendar URL.
-  let calendarUrl = req.query.url;
+  let calendarSrc = req.query.src;
   for (const [key, value] of Object.entries(req.query).slice(1)) {
-    calendarUrl += `&${key}=${value}`;
+    calendarSrc += `&${key}=${value}`;
   }
+  console.debug(`[/api/ical/parse.json] calendarSrc: ${calendarSrc}`);
 
-  console.debug(`[/api/ical/parse.json] calendarUrl: ${calendarUrl}`);
-  const cards = await getCardsFromUrl(calendarUrl);
+  const cards = await getCardsFromUrl(calendarSrc);
 
   if (cards !== null) {
     res.writeHead(200, {
@@ -34,7 +34,7 @@ export async function get(req, res, next) {
     });
     res.end(JSON.stringify(cards));
   } else {
-    console.error(`Could not get cards from ${calendarUrl}`);
+    console.error(`Could not get cards from ${calendarSrc}`);
     next();
   }
 }

--- a/src/routes/api/ical/parse.json.js
+++ b/src/routes/api/ical/parse.json.js
@@ -1,4 +1,4 @@
-import { getCardsFromUrl } from "./_ical.js";
+import { getCardsFromUrl, getCardsFromGoogleCalendarId } from "./_ical.js";
 
 export async function get(req, res, next) {
   // TODO: Make this feel less like a hack.
@@ -24,7 +24,18 @@ export async function get(req, res, next) {
   }
   console.debug(`[/api/ical/parse.json] calendarSrc: ${calendarSrc}`);
 
-  const cards = await getCardsFromUrl(calendarSrc);
+  const googleCalendarIdRegex = /calendar.google.com$/i;
+  const isGoogleCalendarId = googleCalendarIdRegex.test(calendarSrc);
+
+  let cards;
+  if (isGoogleCalendarId) {
+    cards = await getCardsFromGoogleCalendarId(
+      calendarSrc,
+      req.session.access_token
+    );
+  } else {
+    cards = await getCardsFromUrl(calendarSrc);
+  }
 
   if (cards !== null) {
     res.writeHead(200, {

--- a/src/routes/util/_sync.js
+++ b/src/routes/util/_sync.js
@@ -12,7 +12,7 @@ export async function syncCards(session, fetch) {
   for (const calendar of session.calendars) {
     calendarFetches = [
       ...calendarFetches,
-      fetch(`/api/ical/parse.json?url=${calendar.url}`),
+      fetch(`/api/ical/parse.json?src=${calendar.src}`),
     ];
   }
 

--- a/src/routes/util/_sync.js
+++ b/src/routes/util/_sync.js
@@ -10,9 +10,10 @@ export async function syncCards(session, fetch) {
 
   let calendarFetches = [];
   for (const calendar of session.calendars) {
+    const encodedSrc = encodeURIComponent(calendar.src);
     calendarFetches = [
       ...calendarFetches,
-      fetch(`/api/ical/parse.json?src=${calendar.src}`),
+      fetch(`/api/ical/parse.json?src=${encodedSrc}`),
     ];
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -32,6 +32,7 @@ const server = polka() // You can also use Express
         lists: req.session.lists,
         archived_cards: req.session.archived_cards,
         calendars: req.session.calendars,
+        access_token: req.session.access_token,
         GOOGLE_OAUTH2_CLIENT_ID,
       }),
     })


### PR DESCRIPTION
This PR allows users to sync their Google Calendars through their Calendar IDs.

A user can get the Calendar ID by going to the calendar's menu > Settings > Integrate calendar.

![image](https://user-images.githubusercontent.com/4997633/122056380-1d3ee780-ce1c-11eb-8341-d52b4d390367.png)

![image](https://user-images.githubusercontent.com/4997633/122056011-c5a07c00-ce1b-11eb-9aeb-fb478f632c0d.png)

This seems a little too obfuscated for the user to easily find. In the future, we can possibly show a user-facing list of Google Calendars that they would like to add to CalPal (which is also possible through the Google Calendar API).

For now, we should make it clear to the user that they can now enter these Google Calendar IDs. We should probably put this somewhere in the AddCalendar modal. Maybe even in the introductory card?

An important thing to note with this PR is that it now checks whether the Google account you're signing in with is one of the test users defined in CalPal's Google Console. This is probably due to the fact that we're actually requesting user data that goes beyond the basic scope (i.e. their name, email, unique user ID).

Lastly, there's a drive-by change which improves page refresh behavior. We now overwrite the client's session (*only* with regards to the user's data) with the server's session.

This PR resolves #51.