### PR TITLE
Improve UI so users know that they can also sync Google Calendars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "google-auth-library": "^7.0.4",
         "googleapis": "^76.0.0",
         "mongodb": "^3.6.5",
+        "node-fetch": "^2.6.1",
         "node-ical": "^0.13.0",
         "polka": "next",
         "sirv": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "google-auth-library": "^7.0.4",
     "googleapis": "^76.0.0",
     "mongodb": "^3.6.5",
+    "node-fetch": "^2.6.1",
     "node-ical": "^0.13.0",
     "polka": "next",
     "sirv": "^1.0.0"

--- a/src/components/AddCalendar.svelte
+++ b/src/components/AddCalendar.svelte
@@ -112,8 +112,7 @@
 
   const isCalendarAdded = () => {
     for (const calendar of $session.calendars) {
-      if (calendar.src === inputSrc)
-        return true;
+      if (calendar.src === inputSrc) return true;
     }
     return false;
   };

--- a/src/components/AddCalendar.svelte
+++ b/src/components/AddCalendar.svelte
@@ -109,6 +109,14 @@
       },
     ];
   };
+
+  const isCalendarAdded = () => {
+    for (const calendar of $session.calendars) {
+      if (calendar.src === inputSrc)
+        return true;
+    }
+    return false;
+  };
 </script>
 
 <div class="add-calendar-parent">
@@ -188,6 +196,10 @@
         on:click={async () => {
           if (!calendarName || !inputSrc) {
             errorMessage = "Both fields are required.";
+            return;
+          }
+          if (isCalendarAdded()) {
+            errorMessage = "Calendar has already been added.";
             return;
           }
 

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -2,23 +2,34 @@
   import { Col, Row } from "sveltestrap";
   import NavBar from "./NavBar.svelte";
 
-  export let isBoardShown;
+  export let isBoardShown = true;
+  const onLogoClick = async () => {
+    isBoardShown = true;
+  };
 </script>
 
 <div class="header-parent">
   <Row class="header-header">
     <Col class="d-none d-sm-block">
-      <button class="calpal-logo-button" onClick="window.location.reload()">
-        <img src="CalPal_logo.png" alt="CalPal Logo" />
+      <a
+        class="calpal-logo-button"
+        href="/board"
+        on:click={() => onLogoClick()}
+      >
+        <img src="CalPal_logo.png" alt="CalPal" />
         <span class="calpal cal">Cal</span>
         <span class="calpal pal">Pal</span>
-      </button>
+      </a>
     </Col>
     <Col class="d-block d-sm-none">
       <!-- TODO: Tweak the padding to make it match on `sm` and above devices -->
-      <p class="overflow" style="padding-top: 0.75rem;">
-        <img src="CalPal_logo.png" alt="CalPal Logo" />
-      </p>
+      <a
+        class="calpal-logo-button"
+        href="/board"
+        on:click={() => onLogoClick()}
+      >
+        <img src="CalPal_logo.png" alt="CalPal" />
+      </a>
     </Col>
     <Col class="d-xs-block"><NavBar bind:isBoardShown /></Col>
   </Row>
@@ -41,11 +52,12 @@
   }
 
   .calpal-logo-button {
+    color: unset;
+    text-decoration: unset;
     background-color: transparent;
     border: none;
     outline: none;
     line-height: 0%;
-    padding: 1.5% 0% 1.5% 0%;
     transition: transform 0.05s;
     transform-origin: center center;
     white-space: nowrap;

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -3,6 +3,8 @@
   import NavBar from "./NavBar.svelte";
 
   export let isBoardShown = true;
+  export let disableNavBar = false;
+
   const onLogoClick = async () => {
     isBoardShown = true;
   };
@@ -31,7 +33,9 @@
         <img src="CalPal_logo.png" alt="CalPal" />
       </a>
     </Col>
-    <Col class="d-xs-block"><NavBar bind:isBoardShown /></Col>
+    {#if !disableNavBar}
+      <Col class="d-xs-block"><NavBar bind:isBoardShown /></Col>
+    {/if}
   </Row>
 </div>
 

--- a/src/components/MenuSidebar.svelte
+++ b/src/components/MenuSidebar.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Offcanvas, Row, Col, Tooltip } from "sveltestrap";
+  import { Offcanvas, Row, Col, Tooltip, Button, Icon } from "sveltestrap";
   import ArchiveSidebar from "./ArchiveSidebar.svelte";
   import SyncedCalendarsSidebar from "./SyncedCalendarsSidebar.svelte";
   import SettingsSidebar from "./SettingsSidebar.svelte";
@@ -25,6 +25,13 @@
         <ArchiveSidebar bind:isSidebarOpen />
         <br />
         <SyncedCalendarsSidebar bind:isSidebarOpen />
+        <br />
+        <a href="/help" target="_blank">
+          <Button outline secondary style="width: 100%; color: black;">
+            <Icon name="question-circle-fill" />
+            Help
+          </Button>
+        </a>
       </div>
       <div>
         <Row>
@@ -64,6 +71,11 @@
 
   .scale-on-hover:hover {
     transform: scale(1.1);
+  }
+
+  a {
+    color: unset;
+    text-decoration: unset;
   }
 
   img {

--- a/src/routes/api/ical/parse.json.js
+++ b/src/routes/api/ical/parse.json.js
@@ -24,8 +24,8 @@ export async function get(req, res, next) {
   }
   console.debug(`[/api/ical/parse.json] calendarSrc: ${calendarSrc}`);
 
-  const googleCalendarIdRegex = /calendar.google.com$/i;
-  const isGoogleCalendarId = googleCalendarIdRegex.test(calendarSrc);
+  const iCalUrlRegex = /^http/i;
+  const isGoogleCalendarId = !iCalUrlRegex.test(calendarSrc);
 
   let cards;
   if (isGoogleCalendarId) {

--- a/src/routes/api/ical/parse.json.js
+++ b/src/routes/api/ical/parse.json.js
@@ -28,16 +28,20 @@ export async function get(req, res, next) {
   const isGoogleCalendarId = !iCalUrlRegex.test(calendarSrc);
 
   let cards;
-  if (isGoogleCalendarId) {
-    cards = await getCardsFromGoogleCalendarId(
-      calendarSrc,
-      req.session.access_token
-    );
-  } else {
-    cards = await getCardsFromUrl(calendarSrc);
+  try {
+    if (isGoogleCalendarId) {
+      cards = await getCardsFromGoogleCalendarId(
+        calendarSrc,
+        req.session.access_token
+      );
+    } else {
+      cards = await getCardsFromUrl(calendarSrc);
+    }
+  } catch (err) {
+    console.error(err);
   }
 
-  if (cards !== null) {
+  if (cards != null) {
     res.writeHead(200, {
       headers: {
         "Content-Type": "application/json",

--- a/src/routes/help/index.svelte
+++ b/src/routes/help/index.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { Container, Row, Col } from "sveltestrap";
+  import Header from "../../components/Header.svelte";
+</script>
+
+<svelte:head>
+  <title>CalPal Help</title>
+</svelte:head>
+
+<Header disableNavBar={true} />
+<Container style="margin-top: 2rem;">
+  <Row>
+    <Col>
+      <h1>Help</h1>
+      <ul>
+        <li>
+          <a href="/help/syncing-google-calendars">Syncing Google Calendars</a>
+        </li>
+      </ul>
+    </Col>
+  </Row>
+</Container>
+
+<style>
+  ul {
+    list-style: none;
+    margin-left: 0;
+    padding-left: 1.2em;
+  }
+</style>

--- a/src/routes/help/syncing-google-calendars.svelte
+++ b/src/routes/help/syncing-google-calendars.svelte
@@ -1,0 +1,112 @@
+<script>
+  import { Container, Row, Col, Icon } from "sveltestrap";
+  import Header from "../../components/Header.svelte";
+</script>
+
+<svelte:head>
+  <title>CalPal Help - Syncing Google Calendars</title>
+</svelte:head>
+
+<Header disableNavBar={true} />
+<Container style="margin-top: 2rem;">
+  <Row>
+    <Col>
+      <a href="/help"> <Icon name="arrow-left" /> Back to Help</a>
+      <br />
+      <h1>Syncing Google Calendars</h1>
+      <p>
+        This guide will help you sync your Google Calendars to CalPal. When you
+        sync your Google Calendar, any new events are added to the Board as
+        Cards!
+      </p>
+      <div class="img-group">
+        <a
+          href="/help/syncing-google-calendars/calendarsettings.png"
+          target="_blank"
+        >
+          <img
+            src="/help/syncing-google-calendars/calendarsettings.png"
+            alt="Google Calendar settings"
+            class="img-fluid"
+          />
+        </a>
+        <a
+          href="/help/syncing-google-calendars/calendarsidebar.png"
+          target="_blank"
+        >
+          <img
+            src="/help/syncing-google-calendars/calendarsidebar.png"
+            alt="Google Calendar sidebar"
+            class="img-fluid"
+          />
+        </a>
+        <a href="/help/syncing-google-calendars/calendarid.png" target="_blank">
+          <img
+            src="/help/syncing-google-calendars/calendarid.png"
+            alt="Google Calendar ID"
+            class="img-fluid"
+          />
+        </a>
+        <a
+          href="/help/syncing-google-calendars/addcalendar.png"
+          target="_blank"
+        >
+          <img
+            src="/help/syncing-google-calendars/addcalendar.png"
+            alt="Add Calendar modal"
+            class="img-fluid"
+          />
+        </a>
+      </div>
+      <br />
+      <ol>
+        <li>Go to Google Calendar.</li>
+        <li>Open Google Calendar settings.</li>
+        <li>
+          For personal calendars, go to <strong>
+            'Settings for my calendars'
+          </strong>
+          section. For shared calendars, go to
+          <strong>'Settings for other calendars'</strong> section.
+        </li>
+        <li>Select the calendar to be synced.</li>
+        <li>
+          A drop down menu will open. Scroll down to <strong>
+            'Integrate calendar'.
+          </strong>
+        </li>
+        <li>Look for the <strong>Calendar ID</strong> and copy it.</li>
+        <li>In CalPal, click the <strong>Add Calendar</strong> button.</li>
+        <li>Select the <strong>Google Calendar ID</strong> option.</li>
+        <li>
+          Add your preferred calendar title and <strong>
+            paste the Calendar ID
+          </strong> copied from your chosen Google Calendar.
+        </li>
+        <li>Click <strong>Add Calendar.</strong></li>
+      </ol>
+      <p>
+        CalPal will sync your calendar and events. Cards will be automatically
+        created from the synced calendar events.
+      </p>
+      <p>
+        If there aren't any new Cards, try checking whether there are events in
+        your Google Calendar.
+      </p>
+    </Col>
+  </Row>
+</Container>
+
+<style>
+  a {
+    text-decoration: unset;
+  }
+
+  .img-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    margin: 1rem;
+  }
+</style>

--- a/static/help/syncing-google-calendars/addcalendar.png
+++ b/static/help/syncing-google-calendars/addcalendar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:204fb9f59a4ff4ba9a93379638a2765dbbae9e989089ddd72b4b157452996ff1
+size 83869

--- a/static/help/syncing-google-calendars/calendarid.png
+++ b/static/help/syncing-google-calendars/calendarid.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1554e70e37400609c6b59038331b1fdcb69647757b5a3d9fec7a3d083699115a
+size 61093

--- a/static/help/syncing-google-calendars/calendarsettings.png
+++ b/static/help/syncing-google-calendars/calendarsettings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b636d41d3c6797286971a9cdf54c3fb0721c17b690b1d0d7857097e87fc73ce
+size 55511

--- a/static/help/syncing-google-calendars/calendarsidebar.png
+++ b/static/help/syncing-google-calendars/calendarsidebar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6adad9ec71edb660a031736e34a207d4416ddf57cb6ba5c15ea0b25c843009a5
+size 48632


### PR DESCRIPTION
Syncing via Google Calendar IDs is kind of obfuscated from the user and can be confusing for new users. This PR aims to improve upon this by guiding the user in syncing their Google Calendars.

These should be implemented to achieve this goal:
  - [x] Improve AddCalendar UI to show that syncing Google Calendars are possible
  - [x] Create a step-by-step help page with images showing where to find Google Calendar IDs (and linking this page somewhere in an intro Card)